### PR TITLE
Added support for request body options

### DIFF
--- a/examples/draft-04/v1.0.0/reqBodyContentType.json
+++ b/examples/draft-04/v1.0.0/reqBodyContentType.json
@@ -35,6 +35,11 @@
       ],
       "dataMode": "params",
       "dataDisabled": true,
+      "dataOptions": {
+        "raw": {
+          "language": "text"
+        }
+      },
       "headerData": [],
       "method": "POST",
       "pathVariableData": [],

--- a/examples/draft-04/v2.0.0/reqBodyContentType.json
+++ b/examples/draft-04/v2.0.0/reqBodyContentType.json
@@ -24,6 +24,11 @@
               "type": "file"
             }
           ],
+          "options": {
+            "raw": {
+              "language": "text"
+            }
+          },
           "disabled": true
         },
         "url": "https://postman-echo.com/post"

--- a/examples/draft-04/v2.1.0/reqBodyContentType.json
+++ b/examples/draft-04/v2.1.0/reqBodyContentType.json
@@ -24,6 +24,11 @@
               "type": "file"
             }
           ],
+          "options": {
+            "raw": {
+              "language": "text"
+            }
+          },
           "disabled": true
         },
         "url": {

--- a/examples/draft-07/v1.0.0/reqBodyContentType.json
+++ b/examples/draft-07/v1.0.0/reqBodyContentType.json
@@ -34,6 +34,11 @@
         }
       ],
       "dataMode": "params",
+      "dataOptions": {
+        "raw": {
+          "language": "text"
+        }
+      },
       "dataDisabled": true,
       "headerData": [],
       "method": "POST",

--- a/examples/draft-07/v2.0.0/reqBodyContentType.json
+++ b/examples/draft-07/v2.0.0/reqBodyContentType.json
@@ -24,6 +24,11 @@
               "type": "file"
             }
           ],
+          "options": {
+            "raw": {
+              "language": "text"
+            }
+          },
           "disabled": true
         },
         "url": "https://postman-echo.com/post"

--- a/examples/draft-07/v2.1.0/reqBodyContentType.json
+++ b/examples/draft-07/v2.1.0/reqBodyContentType.json
@@ -24,6 +24,11 @@
               "type": "file"
             }
           ],
+          "options": {
+            "raw": {
+              "language": "text"
+            }
+          },
           "disabled": true
         },
         "url": {

--- a/schemas/draft-04/v1.0.0/collection/request.json
+++ b/schemas/draft-04/v1.0.0/collection/request.json
@@ -42,6 +42,10 @@
         }
       ]
     },
+    "dataOptions": {
+      "type": "object",
+      "description": "Additional configurations and options set for various body modes."
+    },
     "dataDisabled": {
       "type": "boolean",
       "default": false,

--- a/schemas/draft-04/v2.0.0/collection/request.json
+++ b/schemas/draft-04/v2.0.0/collection/request.json
@@ -217,6 +217,10 @@
                 "graphql": {
                   "type": "object"
                 },
+                "options": {
+                  "type": "object",
+                  "description": "Additional configurations and options set for various body modes."
+                },
                 "disabled": {
                   "type": "boolean",
                   "default": false,

--- a/schemas/draft-04/v2.1.0/collection/request.json
+++ b/schemas/draft-04/v2.1.0/collection/request.json
@@ -217,6 +217,10 @@
                 "graphql": {
                   "type": "object"
                 },
+                "options": {
+                  "type": "object",
+                  "description": "Additional configurations and options set for various body modes."
+                },
                 "disabled": {
                   "type": "boolean",
                   "default": false,

--- a/schemas/draft-07/v1.0.0/collection/request.json
+++ b/schemas/draft-07/v1.0.0/collection/request.json
@@ -38,6 +38,10 @@
         }
       ]
     },
+    "dataOptions": {
+      "type": "object",
+      "description": "Additional configurations and options set for various body modes."
+    },
     "dataDisabled": {
       "type": "boolean",
       "default": false,

--- a/schemas/draft-07/v2.0.0/collection/request.json
+++ b/schemas/draft-07/v2.0.0/collection/request.json
@@ -207,6 +207,10 @@
                     }
                   }
                 },
+                "options": {
+                  "type": "object",
+                  "description": "Additional configurations and options set for various body modes."
+                },
                 "disabled": {
                   "type": "boolean",
                   "default": false,

--- a/schemas/draft-07/v2.1.0/collection/request.json
+++ b/schemas/draft-07/v2.1.0/collection/request.json
@@ -207,6 +207,10 @@
                     }
                   }
                 },
+                "options": {
+                  "type": "object",
+                  "description": "Additional configurations and options set for various body modes."
+                },
                 "disabled": {
                   "type": "boolean",
                   "default": false,


### PR DESCRIPTION
Added free from object to store request body options.
v1 -> `requests.dataOptions`
v2.x -> `request.body.options`