### PR TITLE
Fix "items" attribute in array schemas

### DIFF
--- a/schemas/draft-04/v2.0.0/collection/certificate.json
+++ b/schemas/draft-04/v2.0.0/collection/certificate.json
@@ -11,7 +11,7 @@
     "matches": {
       "description": "A list of Url match pattern strings, to identify Urls this certificate can be used for.",
       "type": "array",
-      "item": {
+      "items": {
         "type": "string",
         "description": "An Url match pattern string"
       }

--- a/schemas/draft-04/v2.1.0/collection/certificate.json
+++ b/schemas/draft-04/v2.1.0/collection/certificate.json
@@ -12,7 +12,7 @@
     "matches": {
       "description": "A list of Url match pattern strings, to identify Urls this certificate can be used for.",
       "type": "array",
-      "item": {
+      "items": {
         "type": "string",
         "description": "An Url match pattern string"
       }

--- a/schemas/draft-07/v2.0.0/collection/certificate.json
+++ b/schemas/draft-07/v2.0.0/collection/certificate.json
@@ -11,7 +11,7 @@
     "matches": {
       "description": "A list of Url match pattern strings, to identify Urls this certificate can be used for.",
       "type": "array",
-      "item": {
+      "items": {
         "type": "string",
         "description": "An Url match pattern string"
       }

--- a/schemas/draft-07/v2.1.0/collection/certificate.json
+++ b/schemas/draft-07/v2.1.0/collection/certificate.json
@@ -11,7 +11,7 @@
     "matches": {
       "description": "A list of Url match pattern strings, to identify Urls this certificate can be used for.",
       "type": "array",
-      "item": {
+      "items": {
         "type": "string",
         "description": "An Url match pattern string"
       }


### PR DESCRIPTION
Fixes #156 

Inside a schema with type `"array"`, the attribute is called `"items"` and not `"item"`.

---

I hope this is the right place to propose the change. The wrong value can also be seen here:
http://schema.getpostman.com/collection/json/v2.1.0/draft-04/collection.json