### PR TITLE
Updated request.formdata to validate anyOf subschemas

### DIFF
--- a/examples/draft-04/v1.0.0/syncapi.json
+++ b/examples/draft-04/v1.0.0/syncapi.json
@@ -4391,7 +4391,6 @@
         {
           "key": "count",
           "value": "10",
-          "type": "text",
           "enabled": true
         }
       ],

--- a/examples/draft-04/v2.0.0/request.json
+++ b/examples/draft-04/v2.0.0/request.json
@@ -65,7 +65,7 @@
             "value": "application/json; charset=utf8"
           }
         ],
-        "data": {
+        "body": {
           "mode": "formdata",
           "formdata": [
             {
@@ -107,7 +107,6 @@
             {
               "key": "count",
               "value": "10",
-              "type": "text",
               "enabled": true
             }
           ]

--- a/examples/draft-04/v2.1.0/request.json
+++ b/examples/draft-04/v2.1.0/request.json
@@ -65,7 +65,7 @@
             "value": "application/json; charset=utf8"
           }
         ],
-        "data": {
+        "body": {
           "mode": "formdata",
           "formdata": [
             {
@@ -107,7 +107,6 @@
             {
               "key": "count",
               "value": "10",
-              "type": "text",
               "enabled": true
             }
           ]

--- a/examples/draft-07/v1.0.0/syncapi.json
+++ b/examples/draft-07/v1.0.0/syncapi.json
@@ -4391,7 +4391,6 @@
         {
           "key": "count",
           "value": "10",
-          "type": "text",
           "enabled": true
         }
       ],

--- a/examples/draft-07/v2.0.0/request.json
+++ b/examples/draft-07/v2.0.0/request.json
@@ -65,7 +65,7 @@
             "value": "application/json; charset=utf8"
           }
         ],
-        "data": {
+        "body": {
           "mode": "formdata",
           "formdata": [
             {
@@ -107,7 +107,6 @@
             {
               "key": "count",
               "value": "10",
-              "type": "text",
               "enabled": true
             }
           ]

--- a/examples/draft-07/v2.1.0/request.json
+++ b/examples/draft-07/v2.1.0/request.json
@@ -65,7 +65,7 @@
             "value": "application/json; charset=utf8"
           }
         ],
-        "data": {
+        "body": {
           "mode": "formdata",
           "formdata": [
             {
@@ -107,7 +107,6 @@
             {
               "key": "count",
               "value": "10",
-              "type": "text",
               "enabled": true
             }
           ]

--- a/schemas/draft-04/v1.0.0/collection/request.json
+++ b/schemas/draft-04/v1.0.0/collection/request.json
@@ -57,7 +57,7 @@
           "type": "array",
           "description": "Data is an array of key-values that the request goes with. POST data, PUT data, etc goes here.",
           "items": {
-            "oneOf": [
+            "anyOf": [
               {
                 "type": "object",
                 "properties": {

--- a/schemas/draft-04/v2.0.0/collection/request.json
+++ b/schemas/draft-04/v2.0.0/collection/request.json
@@ -118,7 +118,7 @@
                   "items": {
                     "type": "object",
                     "title": "FormParameter",
-                    "oneOf": [
+                    "anyOf": [
                       {
                         "properties": {
                           "key": {

--- a/schemas/draft-04/v2.1.0/collection/request.json
+++ b/schemas/draft-04/v2.1.0/collection/request.json
@@ -118,7 +118,7 @@
                   "items": {
                     "type": "object",
                     "title": "FormParameter",
-                    "oneOf": [
+                    "anyOf": [
                       {
                         "properties": {
                           "key": {

--- a/schemas/draft-07/v1.0.0/collection/request.json
+++ b/schemas/draft-07/v1.0.0/collection/request.json
@@ -53,7 +53,7 @@
           "type": "array",
           "description": "Data is an array of key-values that the request goes with. POST data, PUT data, etc goes here.",
           "items": {
-            "oneOf": [
+            "anyOf": [
               {
                 "type": "object",
                 "properties": {

--- a/schemas/draft-07/v2.0.0/collection/request.json
+++ b/schemas/draft-07/v2.0.0/collection/request.json
@@ -121,7 +121,7 @@
                   "items": {
                     "type": "object",
                     "title": "FormParameter",
-                    "oneOf": [
+                    "anyOf": [
                       {
                         "properties": {
                           "key": {

--- a/schemas/draft-07/v2.1.0/collection/request.json
+++ b/schemas/draft-07/v2.1.0/collection/request.json
@@ -121,7 +121,7 @@
                   "items": {
                     "type": "object",
                     "title": "FormParameter",
-                    "oneOf": [
+                    "anyOf": [
                       {
                         "properties": {
                           "key": {


### PR DESCRIPTION
Use `anyOf` to validate form-data subschemas because according to the schema `type` is not a required property and for an object like:
```json
{
  "key": "foo",
  "value": "bar"
}
```

It matches both the subschemas and validation fails because of the `oneOf` rule.