### PR TITLE
Fix double spaces in "id" description

### DIFF
--- a/schemas/draft-04/v1.0.0/collection/script.json
+++ b/schemas/draft-04/v1.0.0/collection/script.json
@@ -6,7 +6,7 @@
   "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this script from requests.",
       "type": "string"
     },
     "type": {

--- a/schemas/draft-04/v2.0.0-draft.1/collection/script.json
+++ b/schemas/draft-04/v2.0.0-draft.1/collection/script.json
@@ -6,7 +6,7 @@
   "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this script from requests.",
       "type": "string"
     },
     "type": {

--- a/schemas/draft-04/v2.0.0-draft.2/collection/script.json
+++ b/schemas/draft-04/v2.0.0-draft.2/collection/script.json
@@ -6,7 +6,7 @@
   "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this script from requests.",
       "type": "string"
     },
     "type": {

--- a/schemas/draft-04/v2.0.0-draft.4/collection/script.json
+++ b/schemas/draft-04/v2.0.0-draft.4/collection/script.json
@@ -6,7 +6,7 @@
   "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this script from requests.",
       "type": "string"
     },
     "type": {

--- a/schemas/draft-04/v2.0.0-rc.1/collection/script.json
+++ b/schemas/draft-04/v2.0.0-rc.1/collection/script.json
@@ -6,7 +6,7 @@
   "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this script from requests.",
       "type": "string"
     },
     "type": {

--- a/schemas/draft-04/v2.0.0/collection/response.json
+++ b/schemas/draft-04/v2.0.0/collection/response.json
@@ -5,7 +5,7 @@
   "description": "A response represents an HTTP response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this response from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this response from requests.",
       "type": "string"
     },
     "originalRequest": {

--- a/schemas/draft-04/v2.0.0/collection/script.json
+++ b/schemas/draft-04/v2.0.0/collection/script.json
@@ -6,7 +6,7 @@
   "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this script from requests.",
       "type": "string"
     },
     "type": {

--- a/schemas/draft-04/v2.1.0/collection/response.json
+++ b/schemas/draft-04/v2.1.0/collection/response.json
@@ -5,7 +5,7 @@
   "description": "A response represents an HTTP response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this response from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this response from requests.",
       "type": "string"
     },
     "originalRequest": {

--- a/schemas/draft-04/v2.1.0/collection/script.json
+++ b/schemas/draft-04/v2.1.0/collection/script.json
@@ -6,7 +6,7 @@
   "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this script from requests.",
       "type": "string"
     },
     "type": {

--- a/schemas/draft-07/v1.0.0/collection/script.json
+++ b/schemas/draft-07/v1.0.0/collection/script.json
@@ -6,7 +6,7 @@
   "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this script from requests.",
       "type": "string"
     },
     "type": {

--- a/schemas/draft-07/v2.0.0/collection/response.json
+++ b/schemas/draft-07/v2.0.0/collection/response.json
@@ -5,7 +5,7 @@
   "description": "A response represents an HTTP response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this response from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this response from requests.",
       "type": "string"
     },
     "originalRequest": {

--- a/schemas/draft-07/v2.0.0/collection/script.json
+++ b/schemas/draft-07/v2.0.0/collection/script.json
@@ -6,7 +6,7 @@
   "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this script from requests.",
       "type": "string"
     },
     "type": {

--- a/schemas/draft-07/v2.1.0/collection/response.json
+++ b/schemas/draft-07/v2.1.0/collection/response.json
@@ -5,7 +5,7 @@
   "description": "A response represents an HTTP response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this response from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this response from requests.",
       "type": "string"
     },
     "originalRequest": {

--- a/schemas/draft-07/v2.1.0/collection/script.json
+++ b/schemas/draft-07/v2.1.0/collection/script.json
@@ -6,7 +6,7 @@
   "description": "A script is a snippet of Javascript code that can be used to to perform setup or teardown operations on a particular response.",
   "properties": {
     "id": {
-      "description": "A unique, user defined identifier that can  be used to refer to this script from requests.",
+      "description": "A unique, user defined identifier that can be used to refer to this script from requests.",
       "type": "string"
     },
     "type": {


### PR DESCRIPTION
Seems to have been there since ever.

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>