### PR TITLE
response: Describe "_postman_previewlanguage"

### DIFF
--- a/schemas/draft-04/v2.1.0/collection/response.json
+++ b/schemas/draft-04/v2.1.0/collection/response.json
@@ -85,6 +85,11 @@
     "code": {
       "type": "integer",
       "description": "The numerical response code, example: 200, 201, 404, etc."
+    },
+    "_postman_previewlanguage": {
+      "type": "string",
+      "description": "The preview language of the response.",
+      "enum": [ "", "json", "text", "html", "javascript", "plain" ]
     }
   }
 }

--- a/schemas/draft-07/v2.1.0/collection/response.json
+++ b/schemas/draft-07/v2.1.0/collection/response.json
@@ -75,6 +75,11 @@
     "code": {
       "type": "integer",
       "description": "The numerical response code, example: 200, 201, 404, etc."
+    },
+    "_postman_previewlanguage": {
+      "type": "string",
+      "description": "The preview language of the response.",
+      "enum": [ "", "json", "text", "html", "javascript", "plain" ]
     }
   }
 }


### PR DESCRIPTION
The enum is based on the results of doing a global search of
`_postman_previewlanguage` in the Postman org:
https://github.com/search?p=1&q=org%3Apostmanlabs+_postman_previewlanguage&type=Code.

See: https://github.com/postmanlabs/schemas/issues/165
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>